### PR TITLE
Allow setting per-dir paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const minimatch = require('minimatch');
 
-const FORMAT = /^\s*(@?[\w@\.\/-]+)\s*([\w\*\?\.\s-]+)*$/;
+const FORMAT = /^\s*(@?[\w@\.\/-]+)\s*([\w\*\?\.\s\/-]+)*$/;
 
 module.exports = function (contents) {
   const owners = [];


### PR DESCRIPTION
With the current `FORMAT` it is impossible to specify a path not in the root dir, as `*` doesn't span dirs and `**` must be near `/` which was not allowed.